### PR TITLE
[FEATURE] Ajout des headers `X-Forwarded-xxx`.

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -47,5 +47,8 @@ location / {
   # Defining a resolver is required for dynamic DNS resolution
   resolver 8.8.8.8;
 
+  # Set X-Forwarded-xxx headers to let client be aware of original request parameters
+  proxy_set_header X-Forwarded-Host $http_host;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_pass https://$scalingo_app-$pr.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>$prefix$uri$is_args$args;
 }


### PR DESCRIPTION
## :unicorn: Problème
Les review apps de pix-site sont certes accessibles via un sous-domaine de `pix.fr` ou `pix.org`, mais le routage actuels ne permet pas de distinguer, côté serveur, le domaine utilisé.

## :robot: Solution
Ajouter les headers `X-Forwarded-xxx` tels que décrits dans la documentation https://www.nginx.com/resources/wiki/start/topics/examples/likeapache.

## :rainbow: Remarques
On le fait essentiellement pour pix-site qui est une application en nuxt (et donc SSR). Quand la logique pour connaitre la route courante est exécutée côté serveur, on se retrouve avec l'url en scalingo.io.
