### PR TITLE
Ajouter pix-pro pour rediriger pro-pr000.review.pix.fr vers l'URL scalingo

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -44,6 +44,12 @@ location / {
     set $scalingo_app "pix-site-review";
   }
 
+  # If requested app is "pro": route to pix pro application and do not change path
+  if ($app = pro) {
+    set $prefix "";
+    set $scalingo_app "pix-pro-review"; 
+  }
+
   # Defining a resolver is required for dynamic DNS resolution
   resolver 8.8.8.8;
 


### PR DESCRIPTION
Ajout d'une règle pour les review app pour pix-pro

Redirige : `https://pro-pr000.review.pix.fr/`  vers  `https://pix-pro-review-pr000.osc-fr1.scalingo.io/`