### PR TITLE
Ajout de sous-domaines pour les RA epreuves

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -63,6 +63,18 @@ location / {
     set $scalingo_app "pix-tutos-review"; 
   }
 
+  # If requested app is epreuves: route to pix epreuves application and do not change path
+  if ($app = epreuves) {
+    set $prefix "";
+    set $scalingo_app "pix-epreuves-review"; 
+  }
+
+  # If requested app is epreuvesviewer: route to pix epreuves application with viewer path
+  if ($app = epreuvesviewer) {
+    set $prefix "/viewer";
+    set $scalingo_app "pix-epreuves-review"; 
+  }
+
   # Defining a resolver is required for dynamic DNS resolution
   resolver 8.8.8.8;
 


### PR DESCRIPTION
On ajoute :
 - `https://epreuves-prXXX.review.pix.fr/` -> `https://pix-epreuves-review-prXXX.osc-fr1.scalingo.io/`
 - `https://epreuvesviewer-prXXX.review.pix.fr/` -> `https://pix-epreuves-review-prXXX.osc-fr1.scalingo.io/viewer`

On veut deux domaines différents pour avoir des conditions de review plus proches de la prod (En prod les epreuves sont sur epreuves.pix.fr et s'affichent dans une iframe qui est sur app.pix.fr).