### PR TITLE
[TECH] Router les applications par défaut

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*.erb]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+nginx.conf

--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,1 @@
+nginxbase.conf

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Local
+
+## Démarrer nginx en mode debug
+
+Ajouter la directive de debug en haut du fichier `nginx.conf.erb`
+```
+error_log /var/log/nginx/error.log debug;
+```
+
+Démarrer nginx
+``` shell
+erb nginx.conf.erb > nginx.conf
+docker run -v $(pwd)/nginx.conf:/etc/nginx/conf.d/default.conf:ro -p 80:80 --entrypoint nginx-debug nginx '-g daemon off;'
+```
+
+Localiser une review-app active et récupérer le nom de l'application, ici `pix-bot-review-pr202`.
+
+Exécuter cet appel
+``` shell
+curl -H "Host: pix-bot-review-pr202.review.pix.fr" localhost:80/pix-bot-review-pr202
+```
+
+Vérifier les logs: le proxy doit être effectué vers `https://pix-bot-review-pr202.osc-fr1.scalingo.io`.
+
+```shell
+"GET /pix/pix-bot-review-pr202 HTTP/1.0
+X-Forwarded-Host: pix-bot-review-pr202.review.pix.fr
+X-Forwarded-For: 172.17.0.1
+Pix-Application: pix
+Host: pix-pix-review-bot-review-pr202.scalingo.io
+Connection: close
+User-Agent: curl/7.81.0
+Accept: */*
+```

--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -29,50 +29,32 @@ location / {
     set $app "api";
   }
 
-  # Default to routing to front application with app as prefix
-  set $prefix "/$app";
-  set $scalingo_app "pix-front-review";
+  # Default to routing to review application
+  set $prefix "";
+  set $scalingo_app pix-$app-review;
 
-  # If requested app is "api": route to API application and do not change path
-  if ($app = api) {
-    set $prefix "";
-    set $scalingo_app "pix-api-review";
+  # If requested app is one of the pix front: route to pix front review with $app as path prefix
+  if ($app = app ) {
+    set $prefix "/$app";
+    set $scalingo_app "pix-front-review";
   }
-
-  # If requested app is "site": route to pix site application and do not change path
-  if ($app = site) {
-    set $prefix "";
-    set $scalingo_app "pix-site-review";
+  if ($app = certif ) {
+    set $prefix "/$app";
+    set $scalingo_app "pix-front-review";
   }
-
-  # If requested app is "pro": route to pix pro application and do not change path
-  if ($app = pro) {
-    set $prefix "";
-    set $scalingo_app "pix-pro-review"; 
+  if ($app = orga ) {
+    set $prefix "/$app";
+    set $scalingo_app "pix-front-review";
   }
-
-  # If requested app is ui: route to pix ui application and do not change path
-  if ($app = ui) {
-    set $prefix "";
-    set $scalingo_app "pix-ui-review"; 
-  }
-  
-  # If requested app is tutos: route to pix tutos application and do not change path
-  if ($app = tutos) {
-    set $prefix "";
-    set $scalingo_app "pix-tutos-review"; 
-  }
-
-  # If requested app is epreuves: route to pix epreuves application and do not change path
-  if ($app = epreuves) {
-    set $prefix "";
-    set $scalingo_app "pix-epreuves-review"; 
+  if ($app = admin ) {
+    set $prefix "/$app";
+    set $scalingo_app "pix-front-review";
   }
 
   # If requested app is epreuvesviewer: route to pix epreuves application with viewer path
   if ($app = epreuvesviewer) {
     set $prefix "/viewer";
-    set $scalingo_app "pix-epreuves-review"; 
+    set $scalingo_app "pix-epreuves-review";
   }
 
   # Defining a resolver is required for dynamic DNS resolution
@@ -83,6 +65,6 @@ location / {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header Pix-Application $app;
   proxy_pass https://$scalingo_app-$pr.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>$prefix$uri$is_args$args;
-
   proxy_redirect http://$scalingo_app-$pr.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>/ /;
 }
+

--- a/nginxbase.conf
+++ b/nginxbase.conf
@@ -1,0 +1,33 @@
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+    error_log /var/log/nginx/error.log debug;
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+    server{
+        include /etc/nginx/conf.d/*.conf;
+    }
+}


### PR DESCRIPTION
## :christmas_tree: Problème
A chaque ajout d'application Scalingo, il faut modifier la configuration.

## :gift: Proposition
Les ajouter.

## :star2: Remarques
Il n'y a pas de directives pour tester les PR, on les ajoute.
On utilise docker.

## :santa: Pour tester

### Local

Exécuter cet appel
``` shell
curl -H "Host: pix-bot-review-pr202.review.pix.fr" localhost:80/pix-bot-review-pr202
```

Vérifier les logs: le proxy doit être effectué vers `https://pix-bot-review-pr202.osc-fr1.scalingo.io`.

