### PR TITLE
[BUGFIX] Router depuis 1d au lieu de pix1d (PIX-8336)

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -50,7 +50,7 @@ location / {
     set $prefix "/$app";
     set $scalingo_app "pix-front-review";
   }
-  if ($app = pix1d ) {
+  if ($app = 1d ) {
     set $prefix "/$app";
     set $scalingo_app "pix-front-review";
   }


### PR DESCRIPTION
## :unicorn: Problème
Le routeur ne sert pas l'url `1d` mais l'url `pix1d`

## :robot: Proposition
Servir `1d`

## :100: Pour tester
Merger la PR
