### PR TITLE
Permettre de router plusieurs domaines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 nginx.conf
+.env

--- a/README.md
+++ b/README.md
@@ -1,10 +1,30 @@
 # Local
 
-## Deploiement
+## Configuration
 
-Alimenter les variables d'env:
-- API_HOST_SUFFIX :
-- FRONT_REVIEW_APP_NAME_PREFIX :
+La configuration se fait par les variables d'environnement suivantes.
+```dotenv
+# Suffix of the api host
+# obligatoire: oui
+# type: String
+# valeur par défaut: aucune
+# exemple: osc-fr1.scalingo.io
+API_HOST_SUFFIX=
+
+# Prefix name for the front review apps
+# obligatoire: non
+# type: String
+# valeur par défaut: pix
+# exemple: custom-domain
+FRONT_REVIEW_APP_NAME_PREFIX=
+
+# URL du buildpack nginx Scalingo
+# obligatoire: non
+# type: String
+# valeur par défaut: aucune
+# exemple: pix-4pix
+BUILDPACK_URL=https://github.com/Scalingo/nginx-buildpack
+```
 
 ## Démarrer nginx en mode debug
 
@@ -14,7 +34,9 @@ error_log /var/log/nginx/error.log debug;
 ```
 
 Démarrer nginx
-``` shell
+```shell
+  export FRONT_REVIEW_APP_NAME_PREFIX=pix
+  export API_HOST_SUFFIX=osc-fr1.scalingo.io
   erb nginx.conf.erb > nginx.conf
   docker rm review-router
   docker run \
@@ -26,8 +48,9 @@ Démarrer nginx
       nginx '-g daemon off;' 2>&1 \
        |egrep '^(Host: |X-Forwarded-Host: |.GET .* HTTP )'
 ```
+La console doit se mettre en attente.
 
-Verifier les logs du container
+Vérifier les logs du container (dans un autre terminal)
 ```
   docker logs review-router
 ```
@@ -35,7 +58,7 @@ Verifier les logs du container
 Localiser une review-app active et récupérer le nom de l'application, ici `pix-bot-review-pr202`.
 
 Exécuter cet appel
-``` shell
+```shell
 curl -H "Host: bot-pr202.review.pix.fr" localhost:80/url
 ```
 
@@ -47,16 +70,24 @@ X-Forwarded-Host: bot-pr202.review.pix.fr
 Host: pix-bot-review-pr202.scalingo.io
 ```
 
-> Pour les fronts du monorepo, comme la r:eview app est commune à tous les fronts, une configuration spécifique
+> Pour les fronts du monorepo, comme la review app est commune à tous les fronts, une configuration spécifique
 > est mise en place
 
-Pour tester le proxy des fronts du monorepo exécuter ces appels
+Pour tester le proxy des fronts du monorepo, exécuter ces appels.
+
+Si vous utilisez les variables par défaut
 ```shell
-curl -H "Host: app-pr6.review.pix.4pix.digital" localhost:80/connexion
-curl -H "Host: orga-pr202.review.pix.fr" localhost:80/urlorga
+curl -H "Host: app-pr202.review.pix.fr" localhost:80/connexion
+curl -H "Host: orga-pr202.review.pix.fr" localhost:80/campagnes/les-miennes
 ```
 
-Vérifier les logs: le proxy doit être effectué à chaque fois vers la review front
+En alimentant la variable d'env `FRONT_REVIEW_APP_NAME_PREFIX=custom`
+```shell
+curl -H "Host: app-pr202.review.pix.custom.domain" localhost:80/connexion
+curl -H "Host: orga-pr202.review.pix.custom.domain" localhost:80/campagnes/les-miennes
+```
+
+Vérifier les logs : le proxy doit être effectué à chaque fois vers la review front
 `https://pix-front-review-pr202.scalingo.io` avec un path préfixée par le nom de l'application.
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -15,8 +15,21 @@ error_log /var/log/nginx/error.log debug;
 
 Démarrer nginx
 ``` shell
-erb nginx.conf.erb > nginx.conf
-docker run -v $(pwd)/nginxbase.conf:/etc/nginx/nginx.conf:ro -v $(pwd)/nginx.conf:/etc/nginx/conf.d/default.conf:ro --env-file .env -p 80:80 --entrypoint nginx-debug nginx '-g daemon off;' 2>&1 |egrep '^(Host: |X-Forwarded-Host: |.GET .* HTTP)'
+  erb nginx.conf.erb > nginx.conf
+  docker rm review-router
+  docker run \
+      -v $(pwd)/nginxbase.conf:/etc/nginx/nginx.conf:ro \
+      -v $(pwd)/nginx.conf:/etc/nginx/conf.d/default.conf:ro \
+      -p 80:80 \
+      --entrypoint nginx-debug \
+      --name="review-router" \
+      nginx '-g daemon off;' 2>&1 \
+       |egrep '^(Host: |X-Forwarded-Host: |.GET .* HTTP )'
+```
+
+Verifier les logs du container
+```
+  docker logs review-router
 ```
 
 Localiser une review-app active et récupérer le nom de l'application, ici `pix-bot-review-pr202`.
@@ -34,12 +47,12 @@ X-Forwarded-Host: bot-pr202.review.pix.fr
 Host: pix-bot-review-pr202.scalingo.io
 ```
 
-> Pour les fronts du monorepo, comme la review app est commune à tous les fronts, une configuration spécifique
+> Pour les fronts du monorepo, comme la r:eview app est commune à tous les fronts, une configuration spécifique
 > est mise en place
 
 Pour tester le proxy des fronts du monorepo exécuter ces appels
 ```shell
-curl -H "Host: app-pr202.review.pix.fr" localhost:80/urlapp
+curl -H "Host: app-pr6.review.pix.4pix.digital" localhost:80/connexion
 curl -H "Host: orga-pr202.review.pix.fr" localhost:80/urlorga
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Local
 
+## Deploiement
+
+Alimenter les variables d'env:
+- API_HOST_SUFFIX :
+- FRONT_REVIEW_APP_NAME_PREFIX :
+
 ## Démarrer nginx en mode debug
 
 Ajouter la directive de debug en haut du fichier `nginx.conf.erb`
@@ -10,7 +16,7 @@ error_log /var/log/nginx/error.log debug;
 Démarrer nginx
 ``` shell
 erb nginx.conf.erb > nginx.conf
-docker run -v $(pwd)/nginxbase.conf:/etc/nginx/nginx.conf:ro -v $(pwd)/nginx.conf:/etc/nginx/conf.d/default.conf:ro -p 80:80 --entrypoint nginx-debug nginx '-g daemon off;' 2>&1 |egrep '^(Host: |X-Forwarded-Host: |.GET .* HTTP)'
+docker run -v $(pwd)/nginxbase.conf:/etc/nginx/nginx.conf:ro -v $(pwd)/nginx.conf:/etc/nginx/conf.d/default.conf:ro --env-file .env -p 80:80 --entrypoint nginx-debug nginx '-g daemon off;' 2>&1 |egrep '^(Host: |X-Forwarded-Host: |.GET .* HTTP)'
 ```
 
 Localiser une review-app active et récupérer le nom de l'application, ici `pix-bot-review-pr202`.

--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -32,27 +32,28 @@ location / {
   # Default to routing to review application
   set $prefix "";
   set $scalingo_app pix-$app-review;
+  set $front_review_app_name_prefix <%= ENV['FRONT_REVIEW_APP_NAME_PREFIX'] %>;
 
   # If requested app is one of the pix front: route to pix front review with $app as path prefix
   if ($app = app ) {
     set $prefix "/$app";
-    set $scalingo_app "pix-front-review";
+    set $scalingo_app $front_review_app_name_prefix;
   }
   if ($app = certif ) {
     set $prefix "/$app";
-    set $scalingo_app "pix-front-review";
+    set $scalingo_app $front_review_app_name_prefix;
   }
   if ($app = orga ) {
     set $prefix "/$app";
-    set $scalingo_app "pix-front-review";
+    set $scalingo_app $front_review_app_name_prefix;
   }
   if ($app = admin ) {
     set $prefix "/$app";
-    set $scalingo_app "pix-front-review";
+    set $scalingo_app $front_review_app_name_prefix;
   }
   if ($app = 1d ) {
     set $prefix "/$app";
-    set $scalingo_app "pix-front-review";
+    set $scalingo_app $front_review_app_name_prefix;
   }
   # If requested app is epreuvesviewer: route to pix epreuves application with viewer path
   if ($app = epreuvesviewer) {

--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -31,8 +31,9 @@ location / {
 
   # Default to routing to review application
   set $prefix "";
-  set $scalingo_app pix-$app-review;
-  set $front_review_app_name_prefix <%= ENV['FRONT_REVIEW_APP_NAME_PREFIX'] || 'pix-front-review' %>;
+  set $review_app_name_prefix <%= ENV['FRONT_REVIEW_APP_NAME_PREFIX'] || 'pix' %>;
+  set $scalingo_app $review_app_name_prefix-$app-review;
+  set $front_review_app_name_prefix $review_app_name_prefix-front-review;
 
   # If requested app is one of the pix front: route to pix front review with $app as path prefix
   if ($app = app ) {

--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -32,7 +32,7 @@ location / {
   # Default to routing to review application
   set $prefix "";
   set $scalingo_app pix-$app-review;
-  set $front_review_app_name_prefix <%= ENV['FRONT_REVIEW_APP_NAME_PREFIX'] %>;
+  set $front_review_app_name_prefix <%= ENV['FRONT_REVIEW_APP_NAME_PREFIX'] || 'pix-front-review' %>;
 
   # If requested app is one of the pix front: route to pix front review with $app as path prefix
   if ($app = app ) {

--- a/sample.env
+++ b/sample.env
@@ -1,2 +1,0 @@
-API_HOST_SUFFIX=osc-fr1.scalingo.io
-FRONT_REVIEW_APP_NAME_PREFIX=pix-front-review

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,2 @@
+API_HOST_SUFFIX=osc-fr1.scalingo.io
+FRONT_REVIEW_APP_NAME_PREFIX=pix-front-review


### PR DESCRIPTION
## :unicorn: Problème
Le domaine `digital` n'est pas routé.

```
https://app-pr123.     review.pix4.pix.digital                /some/path 
https://pix-4pix-front-review-pr123.osc-fr1.scalingo.io/ app  /some/path
```

## :robot: Proposition
Le router via une variable d'environnement.

## :rainbow: Remarques
Ajout de documentation sur les  variables d'environnement existantes.

## :100: Pour tester

### Local
Utiliser la documentation

### Fork Pix4Pix
Se connecter à https://app-pr8.review.pix4.pix.digital/connexion

### Pix
Mettre à jour la variable d'environnemment (optionnel) pour le monorepo
```
scalingo --region osc-fr1 --app pix-review-router env-set FRONT_REVIEW_APP_NAME_PREFIX=pix
scalingo --region osc-fr1 --app pix-review-router restart
```
Mettre à jour la variable d'environnemment (optionnel) pour le fork du monorepo
```
scalingo --region osc-fr1 --app pix-4pix-review-router env-set FRONT_REVIEW_APP_NAME_PREFIX=pix-4-pix
scalingo --region osc-fr1 --app pix-review-router restart
```
Merger la PR
Accéder à une RA sur chaque repo