### PR TITLE
[TECH] Permettre les reviews des PR SSO dans les Reviews Apps

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -59,7 +59,10 @@ location / {
     set $prefix "/viewer";
     set $scalingo_app "pix-epreuves-review";
   }
-
+  # If app-sso.review.pix.fr route to app.<%= ENV['SSO_REVIEW_APP'] %>.review.pix.fr
+  if ($pr = sso) {
+    set $pr "<%= ENV['SSO_REVIEW_APP'] %>";
+  }
   # Defining a resolver is required for dynamic DNS resolution
   resolver 8.8.8.8;
 


### PR DESCRIPTION
## :unicorn: Problème
L’obligation de déclarer une _« return URL »_ (`redirectUri` en terminologie OIDC) chez les fournisseurs d’identité ne nous permet pas de tester facilement les SSO dans les reviews app dont les URL sont différentes pour chaque pull request.

## :robot: Proposition
Rediriger les requêtes de type `*-sso.review.pix.fr` vers une PR dont le host est dans une var d’env `SSO_REVIEW_APP`

## :rainbow: Remarques
Le test se fait en local.

## :100: Pour tester 
- Choisir une PR ouverte avec une RA active dans le repository Pix, et récupérer son url ; un exemple : https://app-pr8237.review.pix.fr/ 
- Ouvrir un terminal et aller dans le dossier `pix-review-router`
- Taper la commande suivante  en modifiant la valeur de la variable pour qu'elle corresponde à la RA active que vous avez choisie, par exemple : 
   sous Linux et Mac :  `export SSO_REVIEW_APP=pr8237` .
   sous Windows :  `set SSO_REVIEW_APP=pr8237` 
- Taper la commande `erb nginx.conf.erb > nginx.conf`  pour générer le fichier `nginx.conf` avec la bonne valeur de variable 
- Vérifier que dans le fichier `nginx.conf`, la variable $pr doit bien être définie avec le numéro de la RA que vous avez choisie. Un exemple du rendu (lignes 67-68) : 

```
if ($pr = sso) {
    set $pr "pr8237";
  }
```
- Démarrer le conteneur en tapant la commande 
```shell
docker run \
  -v $(pwd)/nginxbase.conf:/etc/nginx/nginx.conf:ro \
  -v $(pwd)/nginx.conf:/etc/nginx/conf.d/default.conf:ro -p 80:80 \
  --entrypoint nginx-debug \
  nginx '-g daemon off;' 2>&1 |egrep '^(Host: |X-Forwarded-Host: |.GET .* HTTP)'
```
- Dans un autre terminal pour faire un appel sur l'url `app-sso.review.pix.fr` taper la commande 
`curl -H "Host: app-sso.review.pix.fr" localhost:80/url`
- Retourner dans le premier terminal et vérifier que vous obtenez la bonne redirection, avec le numéro de la RA que vous avez choisie, par exemple : 
```
GET /app/url HTTP/1.0
X-Forwarded-Host: app-sso.review.pix.fr
Host: pix-front-review-pr8237.scalingo.io
```