### PR TITLE
[FEATURE] Ajout du routage pour pix-epreuves-viewer-review

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -54,6 +54,11 @@ location / {
     set $prefix "/$app";
     set $scalingo_app "pix-front-review";
   }
+  # If epreuves-viewer.review.pix.fr route to pix-epreuves-viewer-review
+  if ($app-$pr = epreuves-viewer) {
+    set $scalingo_app "pix-epreuves-viewer";
+    set $pr "review";
+  }
   # If requested app is epreuvesviewer: route to pix epreuves application with viewer path
   if ($app = epreuvesviewer) {
     set $prefix "/viewer";


### PR DESCRIPTION
## :unicorn: Problème
On aimerait que `epreuves-viewer.review.pix.fr` route vers `pix-epreuves-viewer-review.osc-fr1.scalingo.io`, mais actuellement ça route vers `pix-epreuves-review-viewer.osc-fr1.scalingo.io`...

## :robot: Proposition
Ajouter un `if` spécifique pour cette app.

## :rainbow: Remarques
N/A

## :100: Pour tester
N/A