### PR TITLE
[FEATURE] Supprime la review app Pix 1d au profit de Pix Junior.

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -50,13 +50,8 @@ location / {
     set $prefix "/$app";
     set $scalingo_app "pix-front-review";
   }
-  if ($app = 1d) {
-    set $prefix "/$app";
-    set $scalingo_app "pix-front-review";
-  }
   if ($app = junior) {
-    # former application 1d is now called junior but it is still built in 1d folder
-    set $prefix "/1d";
+    set $prefix "$junior";
     set $scalingo_app "pix-front-review";
   }
    # If epreuves-viewer.review.pix.fr route to pix-epreuves-viewer-review


### PR DESCRIPTION
## :unicorn: Problème

L'application de revue pix 1d n'est plus utile maintenant que l'application de revue pix Junior est fonctionnelle.

## :robot: Proposition
On supprime l'application de revue pix 1d.

## :rainbow: Remarques

RAS

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
