### PR TITLE
[FEATURE] Arrêter l'indexation par les robots

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -72,6 +72,8 @@ location / {
   # Defining a resolver is required for dynamic DNS resolution
   resolver 8.8.8.8;
 
+  add_header X-Robots-Tag noindex always;
+
   # Set X-Forwarded-xxx headers to let client be aware of original request parameters
   proxy_set_header X-Forwarded-Host $http_host;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## :pancakes: Problème

Actuellement, les RA peuvent être indexées. Vous pouvez essayer `site:review.pix.fr` sur Google et voir que ça remonte plein de choses

## :bacon: Proposition

Ajouter le header prévenant les robots de ne pas indexer https://developers.google.com/search/docs/crawling-indexing/block-indexing 
En mettant le header dans ce repo qui est devant toutes nos RA, on s'affranchit de mettre un mécanisme de robots.txt dans chaque repo et de le retirer en production. 

## 🧃 Remarques

Nous avons donc deux mécanismes distincts : 
- le robots.txt, dans le repo qui permet de dire on est sûr qu’on n'en veut pas en prod
- le header ici, qui permet de dire  qu'on est sûr qu’on ne veut jamais indexer toutes lles RA

## :yum: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
