### PR TITLE
[TECH] désactiver le buffering proxy sur l’API

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -78,4 +78,8 @@ location / {
   proxy_set_header Pix-Application $app;
   proxy_pass https://$scalingo_app-$pr.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>$prefix$uri$is_args$args;
   proxy_redirect http://$scalingo_app-$pr.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>/ /;
+
+  if ($app = api) {
+    proxy_buffering off;
+  }
 }


### PR DESCRIPTION
## 🔆 Problème

Le passage par le review router empêche de réceptionner un event stream progressivement.

## ⛱️ Proposition

Désactiver le buffering proxy sur l’API pour vérifier que cela corrige le problème.

## 🌊 Remarques

Ce n’est pas forcément une solution, car cela pourrait avoir des impacts non maitrisés.

## 🏄 Pour tester

N/A