### PR TITLE
[TECH] Désactiver le buffering sur tout le proxy

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -78,8 +78,5 @@ location / {
   proxy_set_header Pix-Application $app;
   proxy_pass https://$scalingo_app-$pr.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>$prefix$uri$is_args$args;
   proxy_redirect http://$scalingo_app-$pr.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>/ /;
-
-  if ($app = api) {
-    proxy_buffering off;
-  }
+  proxy_buffering off;
 }


### PR DESCRIPTION
## 🔆 Problème

Suite à #22, la directive proxy_buffering n’est pas supportée dans un if.

## ⛱️ Proposition

Désactiver le buffering sur toutle proxy.

## 🌊 Remarques

Ce n’est pas forcément voué à rester, on chercher juste à valider que cela permet de streamer une réponse.

## 🏄 Pour tester

N/A