### PR TITLE
[TECH] Réactiver le buffering proxy

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -78,5 +78,4 @@ location / {
   proxy_set_header Pix-Application $app;
   proxy_pass https://$scalingo_app-$pr.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>$prefix$uri$is_args$args;
   proxy_redirect http://$scalingo_app-$pr.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>/ /;
-  proxy_buffering off;
 }


### PR DESCRIPTION
## 🔆 Problème

Les tests sur la désactivation du buffering proxy sont concluants, mais pour le moment on ne souhaite pas conserver cette solution.

## ⛱️ Proposition

Réactiver le buffering proxy.

## 🌊 Remarques

N/A

## 🏄 Pour tester

N/A