### PR TITLE
[TECH] Désactiver le proxy_buffering

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -84,4 +84,5 @@ location / {
   proxy_set_header Pix-Application $app;
   proxy_pass https://$scalingo_app-$pr.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>$prefix$uri$is_args$args;
   proxy_redirect http://$scalingo_app-$pr.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>/ /;
+  proxy_buffering off;
 }


### PR DESCRIPTION
## 🔆 Problème

Le proxy_buffering a été désactivé en prod.

## ⛱️ Proposition

Le désactiver également pour être plus proche de l’env de prod.

## 🌊 Remarques

N/A

## 🏄 Pour tester

N/A