### PR TITLE
add 503 scalingo error for Hera-fallback

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -25,7 +25,7 @@ port_in_redirect off;
 
 access_log off;
 
-error_page 404 = @hera-fallback;
+error_page 404 503 = @hera-fallback;
 
 location / {
   # Consider requested $app to be "api" if the path starts with "/api/"


### PR DESCRIPTION
## 🔆 Problème

Si une review app a été supprimée, scalingo envoie un 503 et non une 404.

## ⛱️ Proposition

Ajout de l'erreur 503 pour la redirection


## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
